### PR TITLE
Fix where physical drive details are fetched from

### DIFF
--- a/hpssa/hpssa.py
+++ b/hpssa/hpssa.py
@@ -341,13 +341,11 @@ class HPSSA(object):
         """
         drive_list = []
         for adapter in self.adapters:
-            if ('slot' not in adapter or
-                    'configuration' not in adapter or
-                    'drives' not in adapter['configuration']):
+            if ('slot' not in adapter or 'configuration' not in adapter):
                 continue
             config = adapter['configuration']
             drive_list.append({'slot': adapter['slot'],
-                               'drives': config['drives'],
+                               'drives': adapter['drives'],
                                'arrays': config.get('arrays', []),
                                'unassigned': config.get('unassigned', [])})
         return drive_list


### PR DESCRIPTION
The original code referenced `drives` which later changed to `logical_drives` and `physical_drives`. This is to correctly reference the adapter configuration to look for `physical_drives`.
