### PR TITLE
Fix where we get adapter information from in a drive config

### DIFF
--- a/hpssa/hpssa.py
+++ b/hpssa/hpssa.py
@@ -358,7 +358,7 @@ class HPSSA(object):
         all_drives = []
         for drive_config in self.get_drive_configuration():
             for drive in drive_config['drives']:
-                all_drives.append(dict(slot=drive['slot'],
+                all_drives.append(dict(slot=drive_config['slot'],
                                        drive_id=self.assemble_id(drive),
                                        **drive))
         return all_drives


### PR DESCRIPTION
This should fix all the previously misused entities :/
