### PR TITLE
Compensate for unsupported/imported config warning messages

### DIFF
--- a/hpssa/hpssa.py
+++ b/hpssa/hpssa.py
@@ -1,4 +1,5 @@
-# Copyright 2015 Jared Rodriguez (jared at blacknode dot net)
+# Copyright 2015-2017 Jared Rodriguez (jared at blacknode dot net)
+# Copyright 2017 Hussam Dawood
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,9 +57,16 @@ def parse_adapter_details(raw_data):
     detail_indent = ' ' * 3
 
     array_details = None
+    reached_adapter_details = False
     for l in raw_data.splitlines():
         if not l:
             continue
+
+        if not reached_adapter_details:
+            if 'in Slot' in l:
+                reached_adapter_details = True
+            else:
+                continue
 
         if l[:3] != detail_indent:  # ascii space
             LOG.debug('Parsing array line: %s' % l)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='python-hpssa',
-    version='0.0.6',
+    version='0.0.7',
     packages=['hpssa'],
     url='',
     license='Apache-2.0',


### PR DESCRIPTION
```
raw_data = """

Controller: Smart Array P840 in slot 3 has an unsupported configuration. You may reconfigure the controller, but the existing conf
iguration and data will be overwritten and potentially lost.

Smart Array P840 in Slot 3
   Bus Interface: PCI
   Slot: 3
```