### PR TITLE
Slot should be treated as an integer

### DIFF
--- a/hpssa/hpssa.py
+++ b/hpssa/hpssa.py
@@ -58,7 +58,7 @@ def __parse_array_name(line):
     matches = re.match('^(?P<name>.*) in Slot (?P<slot>\d+)', line)
     LOG.debug('Found {} in slot {}'.format(matches.group('name'),
                                            matches.group('slot')))
-    return {'name': matches.group('name'), 'slot': matches.group('slot')}
+    return {'name': matches.group('name'), 'slot': int(matches.group('slot'))}
 
 
 def parse_adapter_details(raw_data):
@@ -357,7 +357,7 @@ class HPSSA(object):
     def get_slot_details(self, slot):
         for adapter in self.adapters:
             # TODO: clean up adapter structure, so that ints are ints, OKs or bools, etc
-            if slot == int(adapter['slot']):
+            if int(slot) == int(adapter['slot']):
                 return adapter
         raise HPRaidException('There is no adapter at slot {}'.format(slot))
 


### PR DESCRIPTION
@jr0d - I must have missed the casting of slot when changing over to pulling out name/slot using regex.

It seems like `get_slot_details()` is a safe place to ensure both input and existing adapter details are integers when comparing.