### PR TITLE
To support ssacli

### DIFF
--- a/hpssa/hpssa.py
+++ b/hpssa/hpssa.py
@@ -228,7 +228,7 @@ def parse_show_config(config):
                     )
 
         if line[:3] == _array_indent:
-            if line.find('array') == 3:
+            if line.lower().find('array') == 3:
                 if array_info:
                     arrays.append(array_info)
 
@@ -237,7 +237,7 @@ def parse_show_config(config):
                 array_info['logical_drives'] = []
                 continue
 
-            if line.find('unassigned') == 3:
+            if line.lower().find('unassigned') == 3:
                 if array_info:
                     arrays.append(array_info)
                 array_info = None


### PR DESCRIPTION
Newer HPE ssacli has few changes in output for example:
``` Array A (Solid State SATA, Unused Space: 0  MB)

      logicaldrive 1 (372.58 GB, RAID 1, OK)

      physicaldrive 1I:1:1 (port 1I:box 1:bay 1, SATA SSD, 400 GB, OK)
      physicaldrive 1I:1:2 (port 1I:box 1:bay 2, SATA SSD, 400 GB, OK)

   Unassigned

      physicaldrive 1I:1:3 (port 1I:box 1:bay 3, SATA SSD, 400 GB, OK)
      physicaldrive 1I:1:4 (port 1I:box 1:bay 4, SATA SSD, 400 GB, OK)```

v/s

```array A (SAS, Unused Space: 0  MB)


      logicaldrive 1 (279.4 GB, RAID 1, OK)

      physicaldrive 1I:1:3 (port 1I:box 1:bay 3, SAS, 300 GB, OK)
      physicaldrive 1I:1:4 (port 1I:box 1:bay 4, SAS, 300 GB, OK)

   unassigned

      physicaldrive 1I:1:1 (port 1I:box 1:bay 1, SAS, 6001.1 GB, OK)
      physicaldrive 1I:1:2 (port 1I:box 1:bay 2, SAS, 6001.1 GB, OK)```

To overcome this, we will have convert data into lower case and validate. Made necessary changes, @jr0d  please verify and merge the changes. 